### PR TITLE
closes #6 config through nconf and login fixes

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,1 +1,0 @@
-Apache V2

--- a/node/.cfignore
+++ b/node/.cfignore
@@ -1,4 +1,4 @@
-node_modules
-tmpdata
+/node_modules
+/tmpdata
 .idea
 .settings

--- a/node/app.js
+++ b/node/app.js
@@ -6,7 +6,6 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-var nconf = require('nconf');
 var passportLocal = require('passport-local');
 var busboy = require('connect-busboy');
 var session = require('express-session');
@@ -20,7 +19,7 @@ var onprem = require('./routesapi/onprem');
 var BasicStrategy = require('passport-http').BasicStrategy;
 var FacebookStrategy = require('passport-facebook').Strategy;
 var sanitizeFilename = require('sanitize-filename');
-
+var config = require('./config');
 
 var app = express();
 
@@ -30,23 +29,141 @@ var sessionAndPassport = true; // set to true if session and passport is require
 // return true if the string passed is a good file name
 function saneFilename(fileName) {
     var sane = sanitizeFilename(fileName, {replacement: '_'});
-    if (sane !== fileName) {
-        return false;
+    return sane === fileName;
+}
+
+// return the hostname derived from the initial request.  This is used for passwords and ids so https is appropriate
+function hostnameFromReq(req) {
+    if (req.headers.host === 'localhost') {
+        return String(req.protocol) + "://" + req.headers.host;
     } else {
-        return true;
+        return 'https://' + req.headers.host;
     }
 }
 
-// return the hostname derived from a request
-function hostnameFromReq(req) {
-    return String(req.protocol) + "://" + req.headers.host;
+/**
+ *
+ * @param facebookConf {object} clientId and clientSecret
+ * @param appPath {string} GET path that this app wants to use to initiate a login with facebook
+ * @param hostname {string} http://localhost:3000 is an example this is used for the callback from facebook url
+ * @param facebookCallbackPath {string} second part of the callback from facebook url
+ */
+function facebookConfigure(facebookConf, appPath, hostname, facebookCallbackPath) {
+
+    var callbackUrl = hostname + facebookCallbackPath;
+    debug('facebook callbackUrl: ' + callbackUrl);
+    // Use the FacebookStrategy within Passport.
+    //   Strategies in Passport require a `verify` function, which accept
+    //   credentials (in this case, an accessToken, refreshToken, and Facebook
+    //   profile), and invoke a callback with a user object.
+    passport.use(new FacebookStrategy({
+            clientID: facebookConf.clientId,
+            clientSecret: facebookConf.clientSecret,
+            callbackURL: callbackUrl,
+            profileFields: ['id'] // only need the facebook id
+        }, function (accessToken, refreshToken, profile, done) {
+            // asynchronous verification, for effect...
+            process.nextTick(function () {
+                // keep it simple use the facebook id
+                var userId = "FB_" + profile.id;
+                if (! saneFilename(userId)){throw Error('Facebook user ID is not a valid directory name: ' + userId);}
+                return done(null, {
+                    id: userId
+                });
+            });
+        }
+    ));
+
+    // GET /auth/facebook generated from this application (see view/login) to request a login to facebook
+    // Use passport.authenticate() with facebook app.
+    // The first step in Facebook authentication will involve
+    // redirecting the user to facebook.com.  After authorization, Facebook will
+    // redirect the user back to this application at /auth/facebook/callback
+    app.get(appPath, passport.authenticate('facebook'), function (req, res) {
+        // The request will be redirected to Facebook for authentication, so this
+        // function will not be called.
+        console.error('unexpected facebook callback');
+    });
+
+    // GET /auth/facebook/callback - called after facebook validation.
+    //   Use passport.authenticate() as route middleware to authenticate the
+    //   request.  If authentication fails, the user will be redirected back to the
+    //   login page.  Otherwise, the primary route function function will be called,
+    //   which, in this example, will redirect the user to the home page.
+    app.get(facebookCallbackPath,
+        passport.authenticate('facebook', {failureRedirect: '/login'}), function (req, res) {
+            res.redirect('/');
+        });
+
 }
 
-nconf.argv()
-    .env()
-    .file('./config/app.json');
-var facebookConf = nconf.get('facebook');
-var VCAP_SERVICES = nconf.get('VCAP_SERVICES');
+/**
+ *
+ * @param ssoConfig {object} configuration from VCAP_SERVICES
+ * @param appPath {string} GET path that this app wants to use to initiate a login with sso
+ * @param hostname {string} http://localhost:3000 is an example this is used for the callback from sso url
+ * @param ibmSsoCallbackPath {string} second part of the callback from sso url
+ */
+function ssoConfigure(ssoConfig, appPath, hostname, ibmSsoCallbackPath) {
+    var client_id = ssoConfig.credentials.clientId;
+    var client_secret = ssoConfig.credentials.secret;
+    var authorization_url = ssoConfig.credentials.authorizationEndpointUrl;
+    var token_url = ssoConfig.credentials.tokenEndpointUrl;
+    var issuer_id = ssoConfig.credentials.issuerIdentifier;
+    var callback_url = hostname + ibmSsoCallbackPath;
+    debug('sso callback_url: ' + callback_url);
+
+    var OpenIDConnectStrategy = require('./lib/passport-idaas-openidconnect').IDaaSOIDCStrategy;
+    var ssoStrategy = new OpenIDConnectStrategy({
+            authorizationURL: authorization_url,
+            tokenURL: token_url,
+            clientID: client_id,
+            scope: 'openid',
+            response_type: 'code',
+            clientSecret: client_secret,
+            callbackURL: callback_url,
+            skipUserProfile: true,
+            issuer: issuer_id
+        },
+        function (accessToken, refreshToken, profile, done) {
+            process.nextTick(function () {
+                profile.accessToken = accessToken;
+                profile.refreshToken = refreshToken;
+                var userId = "IBM_" + profile.id;
+                // if (! saneFilename(userId)){throw Error('IBM user ID is not a valid directory name: ' + userId);}
+                return done(null, {
+                    id: userId
+                });
+            })
+        });
+
+    passport.use(ssoStrategy);
+
+    // GET /auth/ibmssologin generated from this application (see view/login) to request a login via IBM sso
+    // Use passport.authenticate() with ibm sso.
+    // redirecting the user to ibm.com.  After authorization, ibm will
+    // redirect the user back to this application at /auth/sso/callback
+    app.get(appPath, passport.authenticate('openidconnect', {}), function (/*req, res*/) {
+        // The request will be redirected to sso for authentication, so this
+        // function will not be called.
+        console.error('unexpected sso callback');
+    });
+
+    // GET /auth/sso/callback - called after ibm sso validation.
+    //   Use passport.authenticate() as route middleware to authenticate the
+    //   request.  If authentication fails, the user will be redirected back to the
+    //   login page.  Otherwise, the primary route function function will be called,
+    //   which, in this example, will redirect the user to the home page.
+    app.get(ibmSsoCallbackPath,
+        passport.authenticate('openidconnect', {failureRedirect: '/login'}), function (req, res) {
+            res.redirect('/');
+        });
+
+    // user hit the DONT ALLOW button instead of Allow or Allow and Remember
+    app.post(ibmSsoCallbackPath, function (req, res) {
+        res.redirect('/');
+    });
+}
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -104,24 +221,30 @@ function pushTopLayerRoutes() {
 // code.  The first outside request will indicate that is is possible to get to the container
 // so it is likely that it will be possible to get outside the container as well.
 var hasBeenContacted = false;
+
+/*jslint unparam: true*/
 function waitForContactThenPushSessionAndPassport(req, res, next) {
     if (hasBeenContacted) return next();
     var hostname = hostnameFromReq(req);
     console.log('hostname: ' + hostname);
     hasBeenContacted = true;
-    var vcapMongo = VCAP_SERVICES.mongolab.find(function(element) {
-        return element.name === 'medicarmongo';
-    });
-    app.use(session({
-        // TODO store: new MongoStore({url: vcapMongo.credentials.uri}),
+    var sesionParameters = {
         resave: 'false',
         saveUninitialized: 'false',
         secret: 'secretusedtosignthesessionidcookie'
-    }));
+    };
+    var vcapMongo = config.findVcapMemberOfServiceByName('serviceSessionStore');
+    if (vcapMongo) {
+        sesionParameters.store = new MongoStore({url: vcapMongo.credentials.uri});
+    } else {
+        console.warn('WARNING: No session storage database service has been configured so sessions are persisted in the default memory storage.  Cloud Foundry autoscale, Container Groups session data will not work well');
+    }
+
+    app.use(session(sesionParameters));
     app.use(passport.initialize());
     app.use(passport.session());
 
-// Passport login configuration
+    // Passport login configuration
     passport.serializeUser(function (user, done) {
         done(null, user.id);
     });
@@ -147,66 +270,17 @@ function waitForContactThenPushSessionAndPassport(req, res, next) {
     // load the strategies into passport
     passport.use(new passportLocal(getIdForUserPassword));
     passport.use(new BasicStrategy({}, getIdForUserPassword));
-    // Use the FacebookStrategy within Passport.
-    //   Strategies in Passport require a `verify` function, which accept
-    //   credentials (in this case, an accessToken, refreshToken, and Facebook
-    //   profile), and invoke a callback with a user object.
-    var facebookCallbackPath = '/auth/facebook/callback';
-    passport.use(new FacebookStrategy({
-            clientID: facebookConf.clientID,
-            clientSecret: facebookConf.clientSecret,
-            callbackURL: hostname + facebookCallbackPath,
-            profileFields: ['id'] // only need the facebook id
-        }, function (accessToken, refreshToken, profile, done) {
-            // asynchronous verification, for effect...
-            process.nextTick(function () {
-                // keep it simple use the facebook id
-                var userId = "FB_" + profile.id;
-                if (! saneFilename(userId)){throw Error('Facebook user ID is not a valid directory name: ' + userId);}
-                return done(null, {
-                    id: userId
-                });
-            });
-        }
-    ));
+
+    var facebookConf = config.nconf.get('CAR_FACEBOOK');
+    if (facebookConf) {
+        facebookConfigure(facebookConf, '/auth/facebook', hostname, '/auth/facebook/callback');
+    }
 
     // Single Sign On IBM:
-    var ssoConfig  = VCAP_SERVICES.SingleSignOn.find(function(element) {
-        return element.name === 'medicarsso';
-    });
-    var client_id = ssoConfig.credentials.clientId;
-    var client_secret = ssoConfig.credentials.secret;
-    var authorization_url = ssoConfig.credentials.authorizationEndpointUrl;
-    var token_url = ssoConfig.credentials.tokenEndpointUrl;
-    var issuer_id = ssoConfig.credentials.issuerIdentifier;
-    var ibmSsoCallbackPath = '/auth/sso/callback';
-    var callback_url = hostname + ibmSsoCallbackPath;
-
-    var OpenIDConnectStrategy = require('./lib/passport-idaas-openidconnect').IDaaSOIDCStrategy;
-    var Strategy = new OpenIDConnectStrategy({
-            authorizationURL: authorization_url,
-            tokenURL: token_url,
-            clientID: client_id,
-            scope: 'openid',
-            response_type: 'code',
-            clientSecret: client_secret,
-            callbackURL: callback_url,
-            skipUserProfile: true,
-            issuer: issuer_id
-        },
-        function (accessToken, refreshToken, profile, done) {
-            process.nextTick(function () {
-                profile.accessToken = accessToken;
-                profile.refreshToken = refreshToken;
-                var userId = "IBM_" + profile.id;
-                // if (! saneFilename(userId)){throw Error('IBM user ID is not a valid directory name: ' + userId);}
-                return done(null, {
-                    id: userId
-                });
-            })
-        });
-
-    passport.use(Strategy);
+    var ssoConfig  = config.findVcapMemberOfServiceByName('serviceSingleSignOn');
+    if (ssoConfig) {
+        ssoConfigure(ssoConfig, '/auth/ibmssologin', hostname, '/auth/sso/callback');
+    }
 
     // The /login page will post a login with user credentials
     app.use('/login', login);
@@ -218,70 +292,25 @@ function waitForContactThenPushSessionAndPassport(req, res, next) {
         res.redirect('/');
     });
 
+
     // Mark the request as private (req.medicar.private == true)
     // if the session has not been authenticated via a passport session then give basic a try
-     function privateCheckAuthorized(req, res, next) {
-         req.medicar = {private: true};
+    function privateCheckAuthorized(req, res, next) {
+        req.medicar = {private: true};
         if (req.isAuthenticated()) {
             return next();
         }
-         // basic authentication is good for curl commands, jmeter, etc, do not persist in the session.
+        // basic authentication is good for curl commands, jmeter, etc, do not persist in the session.
         passport.authenticate('basic', {session: false})(req, res, next);
     }
 
+    // REST API - private portion
     // configure private paths identically
     function appUseCheckAuthorized(path, handler) {
         app.all(path, privateCheckAuthorized);
         app.all(path  + '/*', privateCheckAuthorized);
         app.use(path, handler);
     }
-    // GET /auth/facebook generated from this application (see view/login) to request a login to facebook
-    // Use passport.authenticate() with facebook app.
-    // The first step in Facebook authentication will involve
-    // redirecting the user to facebook.com.  After authorization, Facebook will
-    // redirect the user back to this application at /auth/facebook/callback
-    app.get('/auth/facebook', passport.authenticate('facebook'), function (req, res) {
-        // The request will be redirected to Facebook for authentication, so this
-        // function will not be called.
-        console.error('unexpected facebook callback');
-    });
-
-    // GET /auth/facebook/callback - called after facebook validation.
-    //   Use passport.authenticate() as route middleware to authenticate the
-    //   request.  If authentication fails, the user will be redirected back to the
-    //   login page.  Otherwise, the primary route function function will be called,
-    //   which, in this example, will redirect the user to the home page.
-    app.get(facebookCallbackPath,
-        passport.authenticate('facebook', {failureRedirect: '/login'}), function (req, res) {
-            res.redirect('/');
-        });
-
-
-    // GET /auth/facebook generated from this application (see view/login) to request a login via IBM sso
-    // Use passport.authenticate() with ibm sso.
-    // redirecting the user to ibm.com.  After authorization, ibm will
-    // redirect the user back to this application at /auth/sso/callback
-    app.get('/auth/ibmssologin', passport.authenticate('openidconnect', {}), function (req, res) {
-        // The request will be redirected to Facebook for authentication, so this
-        // function will not be called.
-        console.error('unexpected facebook callback');
-    });
-
-    // GET /auth/sso/callback - called after ibm sso validation.
-    //   Use passport.authenticate() as route middleware to authenticate the
-    //   request.  If authentication fails, the user will be redirected back to the
-    //   login page.  Otherwise, the primary route function function will be called,
-    //   which, in this example, will redirect the user to the home page.
-    app.get(ibmSsoCallbackPath,
-        passport.authenticate('openidconnect', {failureRedirect: '/login'}), function (req, res) {
-            res.redirect('/');
-        });
-
-    // user hit the DONT ALLOW button instead of Allow or Allow and Remember
-    app.post(ibmSsoCallbackPath, function (req, res) {
-        res.redirect('/');
-    });
-    // REST API - private portion
     appUseCheckAuthorized('/api/vol/private', volumeFileRoute);
     appUseCheckAuthorized('/api/obj/private', osv2);
     appUseCheckAuthorized('/api/onprem/private', onprem);

--- a/node/bin/www.js
+++ b/node/bin/www.js
@@ -1,68 +1,29 @@
 #!/usr/bin/env node
-console.log('medicar says hello.  setenv DEBUG=medicar to get a lot more log.  If DEBUG=medicar the next line should be: medicar debugging on');
-
-/**
- * Module dependencies.
- */
-
+console.log('node version: ' + process.version);
+console.log('medicar says hello.  setenv DEBUG=medicar to get a lot more log.  If DEBUG=medicar the next line should read: medicar debugging on');
 var debug = require('debug')('medicar');
 debug('debugging on');
+
 debug('ENV: ');
 debug(process.env);
 var http = require('http');
-var port;
-var bind;
-
-// cloud foundry initialization
-if (runningInCloudFoundry()) {
-    var cfenv = require('cfenv');
-    // get the app environment from Cloud Foundry
-    var appEnv = cfenv.getAppEnv();
-    console.log(appEnv);
-    port = appEnv.port;
-    bind = appEnv.bind;
-    if (!process.env['MR_DATADIR']) {
-        process.env['MR_DATADIR'] = './data'; // set the default to a local directory instead of /data
-    }
-}
-
-/**
- * Get port from environment and store in Express.
- */
-
-console.log('node version: ' + process.version);
-port = port || normalizePort(process.env.PORT || '80');
+var config = require('../config');
 
 var app = require('../app');
+var port = config.nconf.get('CAR_PORT');
+var port = normalizePort(port);
 app.set('port', port);
 
-/**
- * Create HTTP server.
- */
-
 var server = http.createServer(app);
-
-/**
- * Listen on provided port, on all network interfaces.
- */
-if (bind) {
-    server.listen(port, bind);
+var hostname = config.nconf.get('CAR_HOSTNAME');
+if (hostname) {
+    console.log('hostname: ', hostname);
+    server.listen(port, hostname);
 } else {
     server.listen(port);
 }
 server.on('error', onError);
 server.on('listening', onListening);
-
-/**
- *
- * @returns {boolean} true if running in cloud foundry
- */
-function runningInCloudFoundry() {
-    if (process.env['CF_INSTANCE_IP']) {
-        return true;
-    }
-    return false;
-}
 
 /**
  * Normalize a port into a number, string, or false.

--- a/node/config.js
+++ b/node/config.js
@@ -1,38 +1,108 @@
-// VCAP_SERVICES contains all the credentials of services bound to
-// this application. For details of its content, please refer to
-// the document or sample of each service.  
+require('./polyfill');
+
 var debug = require('debug')('medicar');
 var path = require('path');
+var nconf = require('nconf');
+var osv2Authenticate = require('./osv2Authenticate');
 
-// Object Storage V2, osv2, configuration
-// This was provided from the bluemix credential page for the service (not the application binding)
-// copy/paste the string here (make sure it is valid json)
-module.exports.osv2ServiceCredentials;// = '{ "CloudIntegration": { "auth_url": "https://keystone2.open.ibmcloud.com", "swift_url": "https://swift2.open.ibmcloud.com/v1/AUTH_3627c702873a4e9ea92a54cd02d612bc", "sdk_auth_url": "https://keystone2.open.ibmcloud.com", "project": "acme", "region": "dal09", "credentials": { "userid": "pquiring@us.ibm.com", "password": "x8f2,SxA%Ps?{sYL" } } }';
+// all access to nconf should be through this exported variable
+module.exports.nconf = nconf;
 
-// The vcap services will be provided at runtime when the app is bound to a service.
-// On CF bind the service to an app (look at the bound service and you will see a string like the one below)
-// For containers create a CF app bound to the service and then bind the CF app to the container
-// In a debug environment (not bluemix) Open the CF Application > CF OSV2 Service and copy/paste the "bound credentials" for the service below:
-module.exports.processEnvVCAP_SERVICES    = '{ "Object Storage": [ { "name": "osv2-pquiring", "label": "Object Storage", "plan": "Free", "credentials": { "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/2ad3fe49-83e6-492a-836c-bf958318fc0f", "username": "80ce884743da644807120849ca2938bd380c3374", "password": "52bea2ee6fd6666a06dd230ef4fa4c7e7eec0b9f4b144b4cc27a715cf38f" } } ] }';
+// args and environment always win
+nconf.argv()
+    .env();
 
-module.exports.container = process.env.MR_CONTAINER  || 'medical_records_container';
+// if cloud foundry initialization then host, port and default data directory for the file system storage are adjusted
+if (runningInCloudFoundry()) {
+    var cfenv = require('cfenv');
+    // get the app environment from Cloud Foundry
+    var appEnv = cfenv.getAppEnv();
+    console.log(appEnv);
+    nconf.defaults({
+        'CAR_HOSTNAME': appEnv.bind,
+        'CAR_PORT': appEnv.port,
+        'CAR_FILE_DATADIR': './data'
+    });
+}
+
+nconf.file('./config/app.json');
+
+// the file holds VCAP_SERVICES conveniently in object format when copy/pasted from the bluemix credential GUI
+// but in the environment (which is typical) it is a string that needs to be parsed
+var VCAP_SERVICES = nconf.get('VCAP_SERVICES');
+if (typeof(VCAP_SERVICES) === 'string') {
+    VCAP_SERVICES = JSON.parse(VCAP_SERVICES);
+}
+
+module.exports.findVcapMemberOfServiceByNameOrExit = findVcapMemberOfServiceByNameOrExit;
+module.exports.findVcapMemberOfServiceByName = findVcapMemberOfServiceByName;
+function findVcapMemberOfServiceByNameOrExit(nconfServiceName) {
+    var ret = findVcapMemberOfServiceByName(nconfServiceName);
+    if (!ret) {
+        console.error('exit 1');
+        process.exit(1);
+    }
+    return ret;
+}
+
+// VCAP_SERVICES have one object per service and then an array of members.
+// return the member that matches the nconf service configuration.
+// log an error and return false if there is a problem with the service
+function findVcapMemberOfServiceByName(nconfServiceName) {
+    var nconfService = nconf.get(nconfServiceName);
+    if (!nconfService) {
+        console.error('Not a configured bluemix service: ' + nconfServiceName);
+        return false;
+    }
+    var service = VCAP_SERVICES[nconfService.serviceName];
+    if (!service) {
+        console.error('The service name: ' + nconfServiceName + ' indicates that the following non existent service should be in VCAP_SERVICES: ' + nconfService.serviceName);
+        return false;
+    }
+
+    var ret = service.find(function (element) {
+        return element.name === nconfService.memberName;
+    });
+    if (!ret) {
+        console.error('The service name: ' + nconfServiceName + '  identifies an existing service : ' + nconfService.serviceName + '  which is missing the named member: ' + nconfService.memberName);
+        return false;
+    }
+    return ret;
+}
+
+// Identify the Object Storage v2 service.
+var vcapOsv2 = findVcapMemberOfServiceByNameOrExit('serviceOsv2');  // use this mechanism
+var osv2ServiceCredentials = nconf.get('osv2ServiceCredentials');   // not required and can be undefined, kept for testing
+if (typeof(osv2ServiceCredentials) === 'string') {
+    osv2ServiceCredentials = JSON.parse(osv2ServiceCredentials);
+}
+module.exports.osv2Authenticate = osv2Authenticate(osv2ServiceCredentials, vcapOsv2);
+
+module.exports.container = nconf.get('CAR_OSV2_PUBLIC_CONTAINER_NAME');
 debug('container: ' + module.exports.container);
 
-module.exports.containerDestroy = false;
-if (typeof process.env.MR_DESTROY_CONTAINER === 'string') {
-    module.exports.containerDestroy = (process.env.MR_DESTROY_CONTAINER.toLowerCase().trim() == 'true');
-}
-if (module.exports.containerDestroy) {
-    debug('config.containerDestroy === true');
-}
+module.exports.containerDestroy = (nconf.get('CAR_OSV2_PUBLIC_CONTAINER_DESTROY').toLowerCase() === 'true');
+debug('config.containerDestroy: ' + module.exports.containerDestroy);
 
 // file system configuration
-module.exports.dataDir = process.env.MR_DATADIR || path.join(path.sep, 'data');    // default to /data and override in a container: docker run -v xxx:/data
+module.exports.dataDir = nconf.get('CAR_FILE_DATADIR').replace(/\//g, path.sep);    // use linux style and replace with the windows path separator
+debug('data directory: ' + module.exports.dataDir);
+
 module.exports.tmp = 'tmp';
 module.exports.HOSTNAME = 'HOSTNAME';
 module.exports.group_id = 'group_id';
 
-// on premise conifguration
+// on premise conifguration.  These strings are similar to those that will be used in production:
 // curl cap-sg-prd-2.integration.ibmcloud.com:15188
-module.exports.onpremHost = 'cap-sg-prd-2.integration.ibmcloud.com';
-module.exports.onpremPort = '15188';
+module.exports.onpremHost = nconf.get('CAR_SG').onpremHost;
+module.exports.onpremPort = nconf.get('CAR_SG').onpremPort;
+
+/**
+ *
+ * @returns {boolean} true if running in cloud foundry
+ */
+function runningInCloudFoundry() {
+    return !!process.env['CF_INSTANCE_IP'];
+
+}
+

--- a/node/config/app.json
+++ b/node/config/app.json
@@ -1,31 +1,98 @@
 {
-  "facebook": {
-    "clientID": "1416497942014095",
-    "clientSecret": "d4b1e22e4cbb3cae5bd469cf1081adcb"
+  "# services used by the application are identified by the VCAP_SERVICES object name and the array member is located by the memberName": "comment",
+  "serviceOsv2": {
+    "serviceName": "Object Storage",
+    "memberName": "pquiring_carcare_osv2"
   },
+  "serviceSessionStore": {
+    "serviceName": "mongolab",
+    "memberName": "pquiring_carcare_mongo"
+  },
+  "serviceSingleSignOn": {
+    "serviceName": "SingleSignOn",
+    "memberName": "pquiring_carcare_sso"
+  },
+  "# Special case code for osv2.  If the osv2ServiceCredentials is configured it will be used instead of the VCAP_SERVICES indirect lookup": "comment",
+  "#osv2ServiceCredentials": {
+    "CloudIntegration": {
+      "auth_url": "https://keystone2.open.ibmcloud.com",
+      "swift_url": "https://swift2.open.ibmcloud.com/v1/AUTH_3627c702873a4e9ea92a54cd02d612bc",
+      "sdk_auth_url": "https://keystone2.open.ibmcloud.com",
+      "project": "acme",
+      "region": "dal09",
+      "credentials": {
+        "userid": "pquiring@us.ibm.com",
+        "password": "x8f2,SxA%Ps?{sYL"
+      }
+    }
+  },
+
+  "# The following capital letters are more likely to be overridden with environment variables.  MR_FACEBOOK:ClientSecret=d4b1e22e4cbb3cae5bd469cf1081adcb for example": "comment",
+  "# Facebook properties should be secure properties in the deploy pipeline": "comment",
+  "CAR_FACEBOOK": {
+    "clientId": "1443155985992042",
+    "clientSecret": "52d05e665d9354bec1579778399ca423"
+  },
+
+  "# Secure Gateway URL and port providing access to the on premise storage": "comment",
+  "CAR_SG": {
+    "onpremHost": "cap-sg-prd-3.integration.ibmcloud.com",
+    "onpremPort": "15207"
+  },
+
+  "# Listen to these. If the hostname is not provided (default) it will not be provided on the server.listen() call see https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback.": "comment",
+  "# If running in bluemix cloud foundry they will be overridden by the CF provided values.": "comment",
+  "#CAR_HOSTNAME": "undefined",
+  "CAR_PORT": "80",
+  "CAR_OSV2_PUBLIC_CONTAINER_NAME": "medical_records_container",
+  "CAR_OSV2_PUBLIC_CONTAINER_DESTROY": "false",
+  "CAR_FILE_DATADIR": "/data",
   "VCAP_SERVICES": {
-      "mongolab": [
+    "Object Storage": [
       {
-        "name": "medicarmongo",
+        "name": "pquiring_carcare_osv2",
+        "label": "Object Storage",
+        "plan": "Free",
+        "credentials": {
+          "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/7435ddac-b448-404c-a701-5a6a25390915",
+          "username": "e32ce1e62d37dcaf14aab57b48337c7fc2caf459",
+          "password": "b1d3b9ed1ab9dd447fa9262ba9ba1f9833681419cc5b80a999f6651c8265"
+        }
+      }
+    ],
+    "SecureGateway": [
+      {
+        "name": "pquiring_carcare_sg",
+        "label": "SecureGateway",
+        "plan": "securegatewayplan",
+        "credentials": {
+          "org_id": "80a485ba-5bb1-424e-93b9-93900d1cd5c3",
+          "space_id": "711d6b59-295d-43e6-b383-990003a96375",
+          "url": "https://sgmanager.ng.bluemix.net"
+        }
+      }
+    ],
+    "mongolab": [
+      {
+        "name": "pquiring_carcare_mongo",
         "label": "mongolab",
         "plan": "sandbox",
         "credentials": {
-          "uri": "mongodb://IbmCloud_vugkd6vn_bsi06h9f_l0ro0s1e:NuN0Fwi-5zLqXptHUyefjwWvEWAwMo_D@ds055110.mongolab.com:55110/IbmCloud_vugkd6vn_bsi06h9f"
+          "uri": "mongodb://IbmCloud_vugkd6vn_f6sphctb_m320bljt:Is864OGldgMGD7m_JOnrVheU5mtHnqqQ@ds061112.mongolab.com:61112/IbmCloud_vugkd6vn_f6sphctb"
         }
       }
-
     ],
     "SingleSignOn": [
       {
-        "name": "medicarsso",
+        "name": "pquiring_carcare_sso",
         "label": "SingleSignOn",
         "plan": "standard",
         "credentials": {
-          "secret": "izMN9P3pJw",
-          "tokenEndpointUrl": "https://medicarsso-r12998984j-ctw5.iam.ibmcloud.com/idaas/oidc/endpoint/default/token",
-          "authorizationEndpointUrl": "https://medicarsso-r12998984j-ctw5.iam.ibmcloud.com/idaas/oidc/endpoint/default/authorize",
-          "issuerIdentifier": "medicarsso-r12998984j-ctw5.iam.ibmcloud.com",
-          "clientId": "JE9JE3rNPd",
+          "secret": "je952immQn",
+          "tokenEndpointUrl": "https://mrsso-tdn92yta4s-cwg2.iam.ibmcloud.com/idaas/oidc/endpoint/default/token",
+          "authorizationEndpointUrl": "https://mrsso-tdn92yta4s-cwg2.iam.ibmcloud.com/idaas/oidc/endpoint/default/authorize",
+          "issuerIdentifier": "mrsso-tdn92yta4s-cwg2.iam.ibmcloud.com",
+          "clientId": "eHlyOP37Vl",
           "serverSupportedScope": [
             "openid"
           ]

--- a/node/osv2Authenticate.js
+++ b/node/osv2Authenticate.js
@@ -4,13 +4,9 @@ var pkgcloud = require('pkgcloud');
 var debug = require('debug')('medicar');
 var Promise = require("bluebird");
 
-var serviceCredentials;          // parsed service creds
-var serviceProviderCredentials;  // parsed vcapServices to use instead of process.env.VCAP_SERVICES
-
 /*
  Object Storage v2 authentication.  Usage:
-
- var osv2Authenticate = require('../osv2Authenticate');
+ var osv2Authenticate = require('../osv2Authenticate')(serviceCredentialString, vcapServicesString);
 
  // call back with an authorized client
  osv2Authenticate.client(function(err, client) {...}
@@ -19,9 +15,6 @@ var serviceProviderCredentials;  // parsed vcapServices to use instead of proces
  osv2Authenticate.promise()
  .then(function (client) {...}
 
- // override the environment variable for the service provider credentials with
- // either directly with the service credential string or with VCAP_SERVICES string
- osv2Authenticate.init(serviceCredentialString, vcapServicesString);
  */
 
 
@@ -31,67 +24,17 @@ var serviceProviderCredentials;  // parsed vcapServices to use instead of proces
  * @property {function} then
  */
 
-
-/**
- *
- * @param {string} [vcapServicesString] vcap credential string that contains 'Object Storage' element. Example: '{ "Object Storage": [ { "name": "osv2-pquiring", "label": "Object Storage", "plan": "Free", "credentials": { "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/98934f3f-0cf7-47fb-b57b-c21b7a26bc95", "username": "982c30b44b1740a17299150b7f55ec3ffde3a48c", "password": "3a503832a08ce23798921fdfeed9ca4e4cea2d9f5a2ce3b36ffc5a454ba1" } } ] }'
- * @return {object} serviceProviderCredentials object representation of the first element of the "Object Storage" array.  Example: { "name": "osv2-pquiring", "label": "Object Storage", "plan": "Free", "credentials": { "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/98934f3f-0cf7-47fb-b57b-c21b7a26bc95", "username": "982c30b44b1740a17299150b7f55ec3ffde3a48c", "password": "3a503832a08ce23798921fdfeed9ca4e4cea2d9f5a2ce3b36ffc5a454ba1" } }
- */
-function serviceProviderCredentialParser(vcapServicesString) {
-    var vcapServices = JSON.parse(vcapServicesString);
-    return vcapServices['Object Storage'][0];
-}
-
-/**
- * Call init to override the environment variable VCAP_SERVICES or override the service credential string.
- * For deploying into bluemix do not do this.
- * @param {string} [serviceCredentialString] service credential json string.  Example: '{ "CloudIntegration": { "auth_url": "https://keystone2.open.ibmcloud.com", "swift_url": "https://swift2.open.ibmcloud.com/v1/AUTH_3627c702873a4e9ea92a54cd02d612bc", "sdk_auth_url": "https://keystone2.open.ibmcloud.com", "project": "acme", "region": "dal09", "credentials": { "userid": "pquiring@us.ibm.com", "password": "x8f2,SxA%Ps?{sYL" } } }'
- * @param {string} [vcapServicesString] vcap credential string that contains 'Object Storage' element. Example: '{ "Object Storage": [ { "name": "osv2-pquiring", "label": "Object Storage", "plan": "Free", "credentials": { "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/98934f3f-0cf7-47fb-b57b-c21b7a26bc95", "username": "982c30b44b1740a17299150b7f55ec3ffde3a48c", "password": "3a503832a08ce23798921fdfeed9ca4e4cea2d9f5a2ce3b36ffc5a454ba1" } } ] }'
- */
-module.exports.init = function (serviceCredentialString, vcapServicesString) {
-    if (serviceCredentialString) {
-        debug('osv2 credentials, will use hard coded service credentials');
-        serviceCredentials = JSON.parse(serviceCredentialString).CloudIntegration;
-    } else if (vcapServicesString) {
-        debug('osv2 credentials, hard coded VCAP_SERVICES are available and will be used if not provided');
-        serviceProviderCredentials = serviceProviderCredentialParser(vcapServicesString);
-    }
-};
-
 // return promise to respond with service credentials.
 // find them via http request from the bound credentials.
 // in bluemix see the service credentials that are bound to the application
-function requestServiceCredentialsFromVcapCredentials() {
-    var credentials;
-    // parse the service provider credentials from a string.  Catch the case where a parse fails.
-    try {
-        if (process.env['VCAP_SERVICES']) {
-            debug('using VCAP_SERVICES environment for credentials');
-            credentials = serviceProviderCredentialParser(process.env['VCAP_SERVICES']).credentials;
-        } else {
-            // were they provided via the init call?
-            if (serviceProviderCredentials) {
-                debug('not using VCAP_SERVICES environment instead using values from init call');
-                credentials = serviceProviderCredentials.credentials;
-            } else {
-                return Promise.reject(Error('VCAP_SERVICES Environment variable not set'));
-            }
-        }
-    } catch (e) {
-        return Promise.reject('error in VCAP_SERVICES environment resulted in this parsing error: ' + e);
-    }
-    var vcap_creds = {
-        "auth_url": credentials.auth_url,
-        "username": credentials.username,
-        "password": credentials.password
-    };
-    var vcap_secret = "Basic " + new Buffer(credentials.username + ":" + credentials.password).toString("base64");
+function requestServiceCredentialsFromVcapCredentials(serviceProviderCredentials) {
+    var vcap_secret = "Basic " + new Buffer(serviceProviderCredentials.username + ":" + serviceProviderCredentials.password).toString("base64");
     var req_options = {
         headers: {
             'accept': 'application/json',
             'Authorization': vcap_secret
         },
-        url: vcap_creds.auth_url,
+        url: serviceProviderCredentials.auth_url,
         timeout: 20000,
         method: 'GET'
     };
@@ -114,18 +57,18 @@ function requestServiceCredentialsFromVcapCredentials() {
 // return promise to respond with service credentials.
 // These are the creds that are in the service (not the bound service)
 // In bluemix ui see the service not the bound service.
-function getOsv2ServiceCredentials() {
+function getOsv2ServiceCredentials(serviceCredentials, serviceProviderCredentials) {
     if (serviceCredentials) { // hard coded service credentials
         return Promise.resolve(serviceCredentials);
     } else {
-        return requestServiceCredentialsFromVcapCredentials();
+        return requestServiceCredentialsFromVcapCredentials(serviceProviderCredentials);
     }
 }
 
 // return promise to respond with an authenticated client.
-module.exports.promise = function getAuthenticatedClient() {
+function getAuthenticatedClient(serviceCredentials, serviceProviderCredentials) {
     //noinspection JSUnresolvedFunction
-    return getOsv2ServiceCredentials()
+    return getOsv2ServiceCredentials(serviceCredentials, serviceProviderCredentials)
         .then(function (serviceCreds) {
             //noinspection JSUnresolvedVariable
             var authenticatedClient = pkgcloud.storage.createClient({
@@ -149,21 +92,51 @@ module.exports.promise = function getAuthenticatedClient() {
                 });
             });
         });
-};
+}
+
 
 /**
- * Call back with an authenticated client
- * @param {authenticatedClientCallback} callback
+ * Call init to override the environment variable VCAP_SERVICES or override the service credential string.
+ * For deploying into bluemix do not do this.
+ * @param {string} [osv2ServiceCredentials] service credential object from the unbound bluemix service.  Example: { CloudIntegration: { auth_url: "https://keystone2...", swift_url: "...", sdk_auth_url: "...", project: "acme", region: "dal09", credentials: {...} } }
+ * @param {string} [vcapOsv2] vcap credential object from the bound bluemix service  'Object Storage' element. Example: '{ "name": "osv2-pquiring", "label": "Object Storage", "plan": "Free", "credentials": { "auth_url": "https://objectstorage.ng.bluemix.net/auth/8259e199-3520-4de6-9180-411aa1788095/98934f3f-0cf7-47fb-b57b-c21b7a26bc95", "username": "982c30b44b1740a17299150b7f55ec3ffde3a48c", "password": "3a503832a08ce23798921fdfeed9ca4e4cea2d9f5a2ce3b36ffc5a454ba1" } }'
  */
-module.exports.client = function (callback) {
-    return module.exports.promise()
-        .then(function (client) {
-            callback(null, client);
-        })
-        .catch(function (err) {
-            callback(err);
-        });
+module.exports = function (osv2ServiceCredentials, vcapOsv2) {
+    var serviceCredentials;          // parsed service creds
+    var serviceProviderCredentials;  // parsed vcapServices to use instead of process.env.VCAP_SERVICES
+
+    if (osv2ServiceCredentials) {
+        debug('osv2 credentials, will use hard coded credentials provided directly by the unbound bluemix service, not the VCAP_SERVICES indirect credentials');
+        serviceCredentials = osv2ServiceCredentials.CloudIntegration;
+    } else if (vcapOsv2) {
+        debug('osv2 credentials, using the VCAP_SERVICES indirect credentials to get the service credentials');
+        serviceProviderCredentials = vcapOsv2.credentials;
+    } else {
+        console.error('Object Storage V2 is not initialized');
+        process.exit(1);
+    }
+
+    return {
+        // return promise to respond with an authenticated client.
+        promise: function () {
+            return getAuthenticatedClient(serviceCredentials, serviceProviderCredentials);
+        },
+        /**
+         * Call back with an authenticated client
+         * @param {authenticatedClientCallback} callback
+         */
+        client: function (callback) {
+            return getAuthenticatedClient(serviceCredentials, serviceProviderCredentials)
+                .then(function (client) {
+                    callback(null, client);
+                })
+                .catch(function (err) {
+                    callback(err);
+                });
+        }
+    };
 };
+
 
 /**
  * @callback authenticatedClientCallback

--- a/node/osv2Initialize.js
+++ b/node/osv2Initialize.js
@@ -1,13 +1,10 @@
 'use strict';
 var debug = require('debug')('medicar');
 var config = require('./config');
-var osv2Authenticate = require('./osv2Authenticate');
 var Promise = require("bluebird");
 
+var osv2Authenticate = config.osv2Authenticate;
 var client; // access this via the initializeOsv2ReturnClient
-
-// initialize with some hard coded defaults....
-osv2Authenticate.init(config.osv2ServiceCredentials, config.processEnvVCAP_SERVICES);
 
 // containerContext is {
 //   name: nameOfContainer,

--- a/node/test/fileTest.js
+++ b/node/test/fileTest.js
@@ -6,9 +6,9 @@ var path = require('path');
 
 // environment variable setup for test setup.  see config.js
 var tmpData = 'tmpdata';
-process.env.MR_CONTAINER = 'test';
-process.env.MR_DESTROY_CONTAINER = 'true';
-process.env.MR_DATADIR = tmpData;
+process.env.CAR_OSV2_PUBLIC_CONTAINER_NAME = 'test';
+process.env.CAR_OSV2_PUBLIC_CONTAINER_DESTROY = 'true';
+process.env.CAR_FILE_DATADIR = tmpData;
 
 var config = require('../config');
 

--- a/node/test/osv2Test.js
+++ b/node/test/osv2Test.js
@@ -1,6 +1,6 @@
 // environment variable setup for test setup.  see config.js
-process.env.MR_CONTAINER = 'test';
-process.env.MR_DESTROY_CONTAINER = 'true';
+process.env.CAR_OSV2_PUBLIC_CONTAINER_NAME = 'test';
+process.env.CAR_OSV2_PUBLIC_CONTAINER_DESTROY = 'true';
 
 // normal
 var assert = require("assert"); // node.js core module

--- a/node/test/osv2api.js
+++ b/node/test/osv2api.js
@@ -1,12 +1,9 @@
 // mocha test
-var osv2Authenticate = require('../osv2Authenticate');
 var config = require('../config');
-
-osv2Authenticate.init(config.osv2ServiceCredentials);
+var osv2Authenticate = config.osv2Authenticate;
 describe('osv2Authenticate', function() {
     it('return a client', function (done) {
-        osv2Authenticate.init(config.osv2ServiceCredentials, config.processEnvVCAP_SERVICES);
-        osv2Authenticate.client(function(err, client) {
+        osv2Authenticate.client(function(err/*, client*/) {
             if (err) {
                 done(err);
             } else {
@@ -19,7 +16,7 @@ describe('osv2Authenticate', function() {
             if (err) {
                 done(err);
             } else {
-                client.getContainers(function (err, containers) {
+                client.getContainers(function (err /*, containers*/) {
                     if (err) {
                         done(err);
                     } else {
@@ -29,14 +26,10 @@ describe('osv2Authenticate', function() {
             }
         });
     });
-    it('delete module and try the initialization via the promise', function (done) {
-        var name = require.resolve('../osv2Authenticate');
-        delete require.cache[name];
-        var osv22 = require('../osv2Authenticate');
-        osv22.init(config.osv2ServiceCredentials, config.processEnvVCAP_SERVICES);
-        osv22.promise()
+    it('osv2Authenticate.promise()', function (done) {
+        osv2Authenticate.promise()
             .then(function (client) {
-                client.getContainers(function (err, containers) {
+                client.getContainers(function (err/*, containers*/) {
                     if (err) {
                         done(err);
                     } else {
@@ -47,12 +40,5 @@ describe('osv2Authenticate', function() {
             .catch(function (err) {
                 done(err);
             });
-    });
-    it('delete both osv2Authenticate and osv2Initialize to start fresh with next test', function (done) {
-        var osv2Authenticate = require.resolve('../osv2Authenticate');
-        var osv2Initialize = require.resolve('../osv2Initialize');
-        delete require.cache[osv2Authenticate];
-        delete require.cache[osv2Initialize];
-        done();
     });
 });

--- a/node/test/testraw.js.BU
+++ b/node/test/testraw.js.BU
@@ -1,8 +1,8 @@
 // environment variable setup for test setup.  see config.js
 var tmpData = 'tmpdata';
-process.env.MR_CONTAINER = 'test';
-process.env.MR_DESTROY_CONTAINER = 'true';
-process.env.MR_DATADIR = tmpData;
+process.env.CAR_OSV2_PUBLIC_CONTAINER_NAME = 'test';
+process.env.CAR_OSV2_PUBLIC_CONTAINER_DESTROY = 'true';
+process.env.CAR_FILE_DATADIR = tmpData;
 
 // Need to do this before initializing routes/files
 var rimraf = require('rimraf')

--- a/node/test2/fileTest.js
+++ b/node/test2/fileTest.js
@@ -7,9 +7,9 @@ var http = require('http');
 
 // environment variable setup for test setup.  see config.js
 var tmpData = 'tmpdata';
-process.env.MR_CONTAINER = 'test';
-process.env.MR_DESTROY_CONTAINER = 'true';
-process.env.MR_DATADIR = tmpData;
+process.env.CAR_OSV2_PUBLIC_CONTAINER_NAME = 'test';
+process.env.CAR_OSV2_PUBLIC_CONTAINER_DESTROY = 'true';
+process.env.CAR_FILE_DATADIR = tmpData;
 
 var config = require('../config');
 


### PR DESCRIPTION
The configuration code was spread out over a lot of files.  Consolidated
into the ncof representation.  This includes defining the order of nconf
hierarchy: argv, env, cloud foundry (optional), config/app.json.

In addition the login was too complicated so pulled out the ibm sso
support and the direct facebook support into separate functions.
